### PR TITLE
docs: reflect Tauri deprecation and Electron migration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 resolver = "2"
 members = [
   "lenzu",
-  "lenzu_client/src-tauri",
+  # lenzu_client/src-tauri: deprecated — Tauri/WebKit2GTK does not support alpha/transparency correctly on X11; replaced by lenzu_server (Electron)
   "prototypes/gtk4_dialogbox_test",
   "prototypes/gtk_gdk_test",
   "prototypes/kakasi-cli-test",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The key difference from browser extensions like Yomitan/Rikaichan: this operates
 ## Architecture (Current)
 
 ```
-lenzu (GTK3 client)               lenzu_server (Tauri 2.x)
+lenzu (GTK3 client)               lenzu_server (Electron)
   floating lens window     UDP     transparent overlay HUD
   X11 root capture       ──────►  renders translated text
   OpenRouter/Gemini API            ArrowUp/Down moves position
@@ -18,7 +18,7 @@ lenzu (GTK3 client)               lenzu_server (Tauri 2.x)
 
 1. **Capture**: `x11rb` captures the X11 root window directly — bypasses GPU-accelerated and hardware-rendered windows correctly.
 2. **OCR/Translation**: Image sent as base64 PNG to OpenRouter (Gemini 2.0 Flash). Returns structured JSON with `original`, `furigana`, `romaji`, `english`, bounding boxes.
-3. **Overlay**: Formatted text sent via UDP loopback to `lenzu_server`, a Tauri 2.x transparent window pinned to screen edge.
+3. **Overlay**: Formatted text sent via UDP loopback to `lenzu_server`, an Electron transparent window pinned to screen edge.
 
 ## Hardware and Privacy
 
@@ -33,7 +33,7 @@ lenzu (GTK3 client)               lenzu_server (Tauri 2.x)
 - [`pango`](https://crates.io/crates/pango) / [`pangocairo`](https://crates.io/crates/pangocairo) — text layout and CJK rendering
 - [`reqwest`](https://crates.io/crates/reqwest) — HTTP client (OpenRouter API)
 - [`isolang`](https://crates.io/crates/isolang) — ISO 639-3 language codes
-- Tauri 2.x (`lenzu_server`) — transparent overlay window
+- Electron (`lenzu_server`) — transparent overlay window
 
 ## Build & Run
 

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -146,8 +146,10 @@ End-user and “single command after clone” flows are not fully covered today.
 ### Must-Have (Linux)
 - `tesseract-ocr` (>=5.0) with `jpn_vert` traineddata
 - `libgtk-3-dev` (GTK3 >=3.24 — **not GTK4**)
-- `libwebkit2gtk-4.1-dev` — **removed from setup.sh**; was required by the deprecated Tauri overlay (`lenzu_client`). Electron bundles its own Chromium — no system WebKit dependency needed.
 - `pkg-config` and `build-essential`
+
+### Optional / Legacy
+- `libwebkit2gtk-4.1-dev` — **removed from setup.sh**; was required by the deprecated Tauri overlay (`lenzu_client`). Electron bundles its own Chromium — no system WebKit dependency needed.
 
 ### Nice-to-Have
 - `opencv` (for advanced preprocessing) - but heavy dependency

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -8,7 +8,7 @@
 - **Overlay HUD**: Separate Electron process (`lenzu_server`) — transparent window, UDP IPC
 - **Interpreter**: Removed (was Kakasi); translation now handled entirely by the LLM
 - **Config**: `lenzu_config.json` with `isolang` language codes and `OverlayRenderMode` enum
-- **Workspace**: Cargo workspace at repo root; member: `lenzu` (client); `lenzu_server` is a separate Node/Electron project
+- **Workspace**: Cargo workspace at repo root; members: `lenzu` (client) and prototypes; `lenzu_server` is a separate Node/Electron project
 
 ## Vision
 Make **Linux the primary platform** with a robust, performant OCR lens that works across Wayland and X11, using open-source tools while maintaining the offline-first, privacy-respecting design.

--- a/docs/planning.md
+++ b/docs/planning.md
@@ -5,10 +5,10 @@
 - **OCR/Translation**: OpenRouter API → Gemini 2.0 Flash (multimodal); returns structured JSON
 - **UI**: GTK3 floating lens window (Cairo + Pango), transparent RGBA
 - **Capture**: X11 root window via `x11rb` (bypasses GPU-accelerated windows correctly)
-- **Overlay HUD**: Separate Tauri 2.x process (`lenzu_server`) — transparent window, UDP IPC
+- **Overlay HUD**: Separate Electron process (`lenzu_server`) — transparent window, UDP IPC
 - **Interpreter**: Removed (was Kakasi); translation now handled entirely by the LLM
 - **Config**: `lenzu_config.json` with `isolang` language codes and `OverlayRenderMode` enum
-- **Workspace**: Cargo workspace at repo root; members: `lenzu` (client), `lenzu_server/src-tauri`
+- **Workspace**: Cargo workspace at repo root; member: `lenzu` (client); `lenzu_server` is a separate Node/Electron project
 
 ## Vision
 Make **Linux the primary platform** with a robust, performant OCR lens that works across Wayland and X11, using open-source tools while maintaining the offline-first, privacy-respecting design.
@@ -24,11 +24,12 @@ Journal Entry (2026-03-28): Starting Phase 2 tasks.
    - Rename package to `lenzu_client`, keep binary name `lenzu`
    **[COMPLETED: 2026-03-28]**
 
-2. **Phase 3 — Migrate Overlay HUD (Tauri → Electron)**
-   - **Rationale**: Tauri's `xfwm4` compositor ghosting issue (alpha-blend accumulation) is persistent despite mitigation; Electron may offer a more robust translucent overlay solution.
+2. **Phase 3 — Migrate Overlay HUD (Tauri → Electron)** **[COMPLETED]**
+   - **Rationale**: Tauri uses WebKit2GTK which does not correctly composite ARGB windows on X11 — alpha pixels vacated by old content are not cleared, causing "ghost text" accumulation. Multiple mitigations were attempted (near-zero background, body-background toggle, synthetic X11 Expose events) but none fully eliminated the artefact under all timing conditions. Electron (Chromium) correctly composites ARGB windows when a compositor is running.
    - [x] Investigate existing Electron translucent overlay projects (e.g., `/home/hidekiai/projects/remote/github/mine/hidekiai/electron-translucent-desktop-overlay`).
-   - [x] Electron `lenzu_server` (`src/main.js` + UDP JSON protocol) wired to `lenzu`: spawn via `npm run start`, `LENZU_OVERLAY_UDP_PORT` syncs with `overlay_udp_port`, `./scripts/run.sh` no longer double-starts the HUD.
-   - [ ] Verify resolution of ghosting and overall functionality on target WM (manual QA).
+   - [x] Electron `lenzu_server` (`src/main.ts` + UDP JSON protocol) wired to `lenzu`: spawned by client, syncs port via `overlay_udp_port`.
+   - [x] Verify ghosting resolved on target WM (manual QA — confirmed).
+   - **Known limitation**: Electron 41+ on X11 shows a thin white titlebar strip at the top of the window despite `frame: false`. Mitigated with `type: 'toolbar'` and `titleBarStyle: 'hidden'` but not fully eliminated on all compositors.
 
 3. **Phase 4 — Local Pre-detection**
    - Use `yolov8n_fp16.onnx` (already in repo) to find text bounding boxes before API call
@@ -145,7 +146,7 @@ End-user and “single command after clone” flows are not fully covered today.
 ### Must-Have (Linux)
 - `tesseract-ocr` (>=5.0) with `jpn_vert` traineddata
 - `libgtk-3-dev` (GTK3 >=3.24 — **not GTK4**)
-- `libwebkit2gtk-4.1-dev` (optional — only if building legacy Tauri experiments in-repo; Electron HUD uses its own Chromium)
+- `libwebkit2gtk-4.1-dev` — **removed from setup.sh**; was required by the deprecated Tauri overlay (`lenzu_client`). Electron bundles its own Chromium — no system WebKit dependency needed.
 - `pkg-config` and `build-essential`
 
 ### Nice-to-Have
@@ -158,7 +159,7 @@ End-user and “single command after clone” flows are not fully covered today.
 
 1. **Tesseract Training**: Investigate manga109s dataset format and training pipeline
 2. **Wayland Portals**: Study `xdg-desktop-portal` API for screen capture permissions
-3. **Tauri overlay positioning**: ArrowUp/Down key cycling (top/center/bottom) already implemented in lenzu_server
+3. **Electron overlay positioning**: ArrowUp/Down key cycling (top/center/bottom) already implemented in lenzu_server
 4. **Performance Profiling**: Profile capture → OCR pipeline to identify bottlenecks
 
 ## Milestones
@@ -166,7 +167,7 @@ End-user and “single command after clone” flows are not fully covered today.
 - [x] **M1**: X11 capture works correctly (bypasses GPU-accelerated windows)
 - [x] **M2**: Structured OCR results via OpenRouter/Gemini multimodal API
 - [x] **M3**: GTK3 lens window with transparent overlay, spinner, flash feedback
-- [x] **M4**: Tauri overlay HUD (`lenzu_server`) integrated into workspace via UDP IPC
+- [x] **M4**: Electron overlay HUD (`lenzu_server`) integrated via UDP IPC (migrated from Tauri/WebKit2GTK due to alpha/transparency bugs)
 - [x] **M5**: Configurable language pair, render mode, and prompt via `lenzu_config.json`
 - [x] **M6**: `lenzu` auto-spawns/kills `lenzu_server` (Phase 2)
 - [ ] **M7**: YOLOv8 pre-detection reduces token cost by 80-90% (Phase 4)
@@ -209,7 +210,7 @@ End-user and “single command after clone” flows are not fully covered today.
 
 ---
 
-**Last Updated**: 2026-03-22
+**Last Updated**: 2026-04-04
 **Maintainer**: Hideki AI
 **Status**: Active development — `RemoteOCR` branch, Phase 2 next
 

--- a/lenzu/PLANNINGS.md
+++ b/lenzu/PLANNINGS.md
@@ -26,7 +26,7 @@ All items below are implemented and on the `RemoteOCR` branch.
 - [x] `overlay_enabled` / `overlay_udp_port` — HUD process integration
 
 ### Overlay HUD — UDP Bridge
-- [x] `send_to_overlay(text, port)` — fires a UDP datagram to the Tauri HUD process
+- [x] `send_to_overlay(text, port)` — fires a UDP datagram to the Electron HUD process
 - [x] `format_for_overlay(results, mode)` — formats `Vec<TranslationResult>` according to `OverlayRenderMode`
   - `debug` mode includes bounding boxes and debug_info per result
   - Single-field modes fall back to `original` if the field is absent
@@ -38,36 +38,34 @@ All items below are implemented and on the `RemoteOCR` branch.
 
 ## ✅ Phase 1B — lenzu_server in Workspace (COMPLETE)
 
-The `tauri-translucent-desktop-overlay` project has been brought into this workspace as `lenzu_server`.
+The overlay HUD was originally the `tauri-translucent-desktop-overlay` project (Tauri + WebKit2GTK). It was replaced with an Electron-based implementation (`electron-translucent-desktop-overlay`) due to WebKit2GTK's broken alpha/transparency compositing on X11 — ghost pixels accumulate as text updates because WebKit's dirty-rect optimiser skips repainting transparent-to-transparent regions. Electron (Chromium) composites ARGB windows correctly when a compositor is running.
 
 ### Structure
 ```
 lenzu/                          ← workspace root
-├── Cargo.toml                  ← workspace (members: lenzu, lenzu_server/src-tauri)
+├── Cargo.toml                  ← workspace (members: lenzu only; lenzu_server is Node/Electron)
 ├── lenzu/                      ← OCR lens client (GTK3)
-└── lenzu_server/
-    ├── package.json            ← @tauri-apps/cli devDep
-    ├── src-tauri/
-    │   ├── Cargo.toml          ← name = "lenzu_server"
-    │   ├── tauri.conf.json     ← productName = "lenzu_server", identifier = com.hidekiai.lenzu-server
-    │   ├── capabilities/
-    │   ├── icons/
-    │   └── src/main.rs         ← UDP listener + Tauri window; accepts --port CLI arg
-    └── ui/
-        ├── index.html
-        ├── app.js              ← listens for "hud-text-changed" Tauri event
-        └── styles.css
+└── lenzu_server/               ← Electron overlay HUD
+    ├── package.json            ← electron, esbuild, vitest devDeps
+    ├── build.mjs               ← esbuild pipeline
+    ├── hud_config.json         ← HUD display settings
+    ├── src/
+    │   ├── main.ts             ← UDP listener + BrowserWindow; transparent, frameless
+    │   ├── preload.ts          ← contextBridge (IPC boundary)
+    │   └── renderer/
+    │       ├── app.ts          ← listens for "hud-text-changed" IPC event
+    │       ├── index.html
+    │       └── styles.css
+    └── scripts/
+        ├── setup.sh            ← Node/pnpm/Electron install + tsc check
+        └── demo.sh             ← build + launch + UDP demo sequence
 ```
-
-### Key change from original overlay
-- `lenzu_server` accepts `--port <N>` CLI argument, which overrides `hud_config.json`.
-  This lets `lenzu_client` pass its configured `overlay_udp_port` at spawn time.
 
 ### Running standalone (for testing)
 ```bash
 cd lenzu_server
-npm install
-npm run tauri dev -- -- --port 7331
+bash scripts/setup.sh   # first time only
+bash scripts/demo.sh    # build, launch, send demo messages
 ```
 
 ---
@@ -131,11 +129,11 @@ Once the client/server lifecycle is stable, revisit the original vision of local
              │ UDP loopback (default :7331)
              ▼
 ┌─────────────────────────────────┐
-│       lenzu_server (Tauri)      │
+│     lenzu_server (Electron)     │
 │  Transparent overlay window     │
-│  UDP listener thread            │
-│  Emits "hud-text-changed" event │
-│  app.js renders text in HUD     │
+│  UDP listener (dgram)           │
+│  IPC: "hud-text-changed"        │
+│  app.ts renders text in HUD     │
 └─────────────────────────────────┘
 ```
 

--- a/lenzu/PLANNINGS.md
+++ b/lenzu/PLANNINGS.md
@@ -42,8 +42,8 @@ The overlay HUD was originally the `tauri-translucent-desktop-overlay` project (
 
 ### Structure
 ```
-lenzu/                          ← workspace root
-├── Cargo.toml                  ← workspace (members: lenzu only; lenzu_server is Node/Electron)
+./                              ← workspace root (repository root)
+├── Cargo.toml                  ← workspace manifest (members: lenzu only; lenzu_server is Node/Electron)
 ├── lenzu/                      ← OCR lens client (GTK3)
 └── lenzu_server/               ← Electron overlay HUD
     ├── package.json            ← electron, esbuild, vitest devDeps

--- a/lenzu/README.md
+++ b/lenzu/README.md
@@ -55,7 +55,7 @@ Lenzu is two processes:
 ### Prerequisites
 
 ```bash
-# System dependencies (GTK3 + capture stack; WebKit only needed if you build old Tauri prototypes)
+# System dependencies (GTK3 + capture stack; no WebKit needed — Electron bundles its own Chromium)
 sudo apt install build-essential pkg-config libgtk-3-dev libcairo2-dev libpango1.0-dev \
                  libgdk-pixbuf-2.0-dev libx11-dev libssl-dev \
                  fonts-noto-cjk fonts-ipafont-gothic

--- a/lenzu_client/README.md
+++ b/lenzu_client/README.md
@@ -13,6 +13,11 @@
 > The remainder of this document is preserved solely as archival reference for the deprecated Tauri/WebKit2GTK overlay.
 > Do **not** use the configuration, compositor, or build steps below for current development or deployment.
 > Use [`../lenzu_server`](../lenzu_server) instead.
+## Historical reference only
+
+> The remainder of this document is preserved solely as archival reference for the deprecated Tauri/WebKit2GTK overlay.
+> Do **not** use the configuration, compositor, or build steps below for current development or deployment.
+> Use [`../lenzu_server`](../lenzu_server) instead.
 
 ## Configuration (`hud_config.json`)
 

--- a/lenzu_client/README.md
+++ b/lenzu_client/README.md
@@ -1,18 +1,12 @@
-# lenzu_server
+# lenzu_client (DEPRECATED — Tauri/WebKit2GTK overlay)
 
-Transparent desktop overlay HUD for the [Lenzu](../lenzu) OCR lens. Receives text via UDP and renders it in a translucent Tauri window pinned to the bottom of the screen.
-
-Part of the Lenzu workspace. In normal use `lenzu` (the client) will spawn and kill this process automatically (Phase 2). For now it must be started separately.
-
-## Running standalone
-
-```bash
-cd lenzu_server
-npm install          # first time only — installs @tauri-apps/cli
-npm run tauri dev -- -- --port 7331
-```
-
-The `--port` argument overrides `hud_config.json`. Use the same port as `overlay_udp_port` in `lenzu/lenzu_config.json`.
+> **This directory is deprecated and no longer used.**
+>
+> The Tauri + WebKit2GTK overlay was abandoned because WebKit2GTK does not correctly composite ARGB windows on X11: alpha pixels vacated by old content are not cleared on the X11 surface, causing "ghost text" accumulation on every text update. Multiple workarounds (near-zero body background, body-background toggle, synthetic X11 Expose events) were attempted but none fully eliminated the artefact under all timing conditions.
+>
+> The active overlay is [`../lenzu_server`](../lenzu_server), which uses **Electron (Chromium)**. Chromium correctly composites ARGB windows when a compositor is running and requires no repaint workarounds.
+>
+> This directory is kept for historical reference only. Do not use it.
 
 ## Configuration (`hud_config.json`)
 

--- a/lenzu_client/README.md
+++ b/lenzu_client/README.md
@@ -8,6 +8,12 @@
 >
 > This directory is kept for historical reference only. Do not use it.
 
+## Historical reference only
+
+> The remainder of this document is preserved solely as archival reference for the deprecated Tauri/WebKit2GTK overlay.
+> Do **not** use the configuration, compositor, or build steps below for current development or deployment.
+> Use [`../lenzu_server`](../lenzu_server) instead.
+
 ## Configuration (`hud_config.json`)
 
 Optional file in this directory. All fields have defaults.

--- a/lenzu_server/README.md
+++ b/lenzu_server/README.md
@@ -5,10 +5,16 @@ messages received over **UDP** as closed-caption / subtitle lines.  The
 overlay is click-through (does not obstruct any other application), always
 on top, and fully configurable for position, translucency and font size.
 
-> Replacement of
+> Replaces the deprecated
 > [tauri-translucent-desktop-overlay](https://github.com/HidekiAI/tauri-translucent-desktop-overlay)
-> which uses WebKit2GTK — known to be buggy for composited transparency on
-> Linux.
+> (Tauri + WebKit2GTK). WebKit2GTK does not correctly composite ARGB windows on
+> X11 — stale alpha pixels accumulate as "ghost text" on every update, and no
+> workaround fully eliminates it. Electron (Chromium) composites ARGB correctly.
+>
+> **Known limitation (Electron 41+ / X11):** A thin white titlebar strip may
+> appear at the top of the window despite `frame: false`. Mitigated with
+> `type: 'toolbar'` + `titleBarStyle: 'hidden'` but not fully eliminated on all
+> compositor/WM combinations.
 
 ![simplescreenrecorder-2026-03-23_18 57 28](https://github.com/user-attachments/assets/b65d6be5-2592-48b9-858d-998f8c873cd8)
 

--- a/lenzu_server/docs/TechDesign.md
+++ b/lenzu_server/docs/TechDesign.md
@@ -186,6 +186,7 @@ Only pure modules are unit-tested. Electron-bound code (`main.ts`, `preload.ts`,
 ## 11. Known limitations
 
 - **X11 only.** Wayland compositors do not implement the same ARGB visual protocol. `--enable-transparent-visuals` has no effect under XWayland. The app should still launch but the background will be opaque.
+- **White titlebar strip (Electron 41+ on X11).** Despite `frame: false`, Electron 41+ can show a thin white strip at the top of the window on some X11 compositors. Mitigated by setting `type: 'toolbar'` and `titleBarStyle: 'hidden'` on `BrowserWindow`, which sets the `_NET_WM_WINDOW_TYPE_TOOLBAR` hint to suppress window-manager decorations. This reduces the strip significantly but may not fully eliminate it on all compositor/WM combinations.
 - **Compositor required.** Without an ARGB compositor the window background is black.
 - **Single window.** Only the primary display's work area is used to size the window. The window is repositioned to whatever display the cursor is on at the time an arrow key is pressed.
 - **No hot reload.** `hud_config.json` is read once at startup. The app must be restarted to pick up config changes.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -23,8 +23,6 @@ sudo apt install -y \
     libx11-dev \
     libxcb1-dev \
     libssl-dev \
-    libwebkit2gtk-4.1-dev \
-    libjavascriptcoregtk-4.1-dev \
     libgtk-4-dev \
     libgraphene-1.0-dev \
     fonts-noto-cjk \


### PR DESCRIPTION
## Summary
- Update all docs/comments to reflect that Tauri/WebKit2GTK was deprecated (broken alpha compositing on X11 → ghost text) and replaced with Electron
- Remove `libwebkit2gtk-4.1-dev` from `scripts/setup.sh` (no longer needed)
- Comment out `lenzu_client/src-tauri` from Cargo workspace
- Add white titlebar known limitation to `lenzu_server` docs

## Test plan
- [x] `cargo check` — passes (1 pre-existing deprecation warning only)
- [x] `pnpm run build` + `tsc --noEmit` — passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)